### PR TITLE
Fix index.html HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <input type="checkbox" id="expand-exp">
         <label for="expand-exp">Expand intermediate expressions</label>
       </div>
-      <div class="row" id="output" />
+      <div class="row" id="output"></div>
     </div>
      <script type="text/javascript">
          proplog.Main().main()


### PR DESCRIPTION
Ran it through https://validator.w3.org/nu/#textarea and found an error that `<div>` cannot be self-closing.

<img width="967" alt="screen shot 2017-05-25 at 15 27 48" src="https://cloud.githubusercontent.com/assets/857609/26454375/d65dca00-415e-11e7-8f74-e97fc1ba94a8.png">
